### PR TITLE
URL update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # urban
 
-The Urban Dictionary doesn't have an actual API, so the data comes from the iPhone page which comes in json format, easy to manipulate: `http://www.urbandictionary.com/iphone/search/define?term=kvlt`
+The Urban Dictionary has a JSON API which can be easily accessed via URLs like this: `http://api.urbandictionary.com/v0/define?term=kvlt`
 
 ### installation
 

--- a/lib/urban.js
+++ b/lib/urban.js
@@ -57,8 +57,8 @@ Dictionary.fn.getData = function(page) {
   this._ended = false;
   this._req = http.get({
     port: 80,
-    host: 'www.urbandictionary.com',
-    path: '/iphone/search/define?page=' + self.page + '&term=' + self.words
+    host: 'api.urbandictionary.com',
+    path: '/v0/define?page=' + self.page + '&term=' + self.words
   }, function(res) {
     self._res = res; // reference
     self.json = '';


### PR DESCRIPTION
It looks like Urban Dictionary recently started redirecting the iphone page to a new JSON API URL.  I just updated the code to hit that new URL.

I wasn't able to find much information about the JSON API, but Urban Dictionary now has this form at the bottom of their website: http://urbandictionary.wufoo.com/forms/api-interest-form/
