### PR TITLE
Prevent handlers from being repeatedly called

### DIFF
--- a/lib/urban.js
+++ b/lib/urban.js
@@ -43,7 +43,7 @@ Dictionary.fn._end = function(fn) {
     fn(this.json);
   }
   else {
-    this.on('end', function(json) {
+    this.once('end', function(json) {
       fn(json);
     });
   }


### PR DESCRIPTION
Using the urban object more than once causes handlers to stack, which I don't think is the desired behavior. 
