### PR TITLE
Fix auto-exit on windows

### DIFF
--- a/bin/urban
+++ b/bin/urban
@@ -21,6 +21,6 @@ else {
       args.push(res.permalink)
     }
     console.log.apply(this, args);
-    process.stdin.destroy();
+    process.stdin.pause();
   });
 }


### PR DESCRIPTION
For some reason, closing stdin with `destroy()` does not allow the script to automatically exit when ran on windows _(Windows 8.1, Node v0.10.31)_.

Instead, closing stdin with `pause()` allows the script to auto-exit as expected.
