### PR TITLE
Make each Dictionary instance have its own event emitter

### DIFF
--- a/lib/urban.js
+++ b/lib/urban.js
@@ -1,5 +1,6 @@
 var http = require('http'),
-EventEmitter = require('events').EventEmitter;
+    util = require('util'),
+    EventEmitter = require('events').EventEmitter;
 
 function urban() {
   var word = new Dictionary(null); // instantiate first
@@ -35,8 +36,8 @@ function Dictionary(words) {
   return this;
 }
 
+util.inherits(Dictionary, EventEmitter);
 Dictionary.fn = Dictionary.prototype;
-Dictionary.fn.__proto__ = new EventEmitter;
 Dictionary.fn._noop = function() {};
 Dictionary.fn._end = function(fn) {
   if (this._ended) {


### PR DESCRIPTION
The current way of setting one shares the same eventemitter between all instances.

This can most easily be seen when you make two queries very quickly for different things and get the same answer twice based on whichever one emits 'end' first.